### PR TITLE
Disable automatic reconnection when WiFi.setAutoReconnect() 

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -1032,7 +1032,7 @@ void WiFiGenericClass::removeEvent(wifi_event_id_t id)
  */
 esp_err_t WiFiGenericClass::_eventCallback(arduino_event_t *event)
 {
-    static bool first_connect = true;
+    static bool first_connect = false;  // Disabled to prevent forced reconnection on first disconnect
 
     if(!event) return ESP_OK;                                                       //Null would crash this function
 


### PR DESCRIPTION
If WiFi.setAutoReconnect() is set with false, reconnection attempts are disabled _except_ that there is a separate `first_connect` method that always tries to reconnect once. Disabling that.