### PR TITLE
fix: set WL_DISCONNECTED for AUTH_EXPIRE disconnect

### DIFF
--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -1066,7 +1066,7 @@ esp_err_t WiFiGenericClass::_eventCallback(arduino_event_t *event)
         } else if(reason == WIFI_REASON_BEACON_TIMEOUT || reason == WIFI_REASON_HANDSHAKE_TIMEOUT) {
             WiFiSTAClass::_setStatus(WL_CONNECTION_LOST);
         } else if(reason == WIFI_REASON_AUTH_EXPIRE) {
-
+            WiFiSTAClass::_setStatus(WL_DISCONNECTED);
         } else {
             WiFiSTAClass::_setStatus(WL_DISCONNECTED);
         }


### PR DESCRIPTION
## Summary

The WiFi disconnect event handler in `WiFiGeneric.cpp` sets `WiFi.status()` for every disconnect reason except `AUTH_EXPIRE`, which had an empty block. This left `WiFi.status()` stuck at `WL_CONNECTED` after an `AUTH_EXPIRE` disconnect.

```cpp
// Before (bug):
} else if(reason == WIFI_REASON_AUTH_EXPIRE) {
    // empty — status stays WL_CONNECTED
} else {

// After (fix):
} else if(reason == WIFI_REASON_AUTH_EXPIRE) {
    WiFiSTAClass::_setStatus(WL_DISCONNECTED);
} else {
```

This is a one-line fix: set `WL_DISCONNECTED` for `AUTH_EXPIRE`, matching the default catch-all used by other unspecialized reason codes.

## Context

Discovered while debugging WiFi reconnection issues in FluidNC (bantamtools/FluidNC-Private#442). Application code checking `WiFi.status() != WL_CONNECTED` to detect disconnection was failing because the status was never updated for `AUTH_EXPIRE` events.

## Test plan

- [x] Code review: confirmed every other reason code in the handler sets a status
- [ ] Hardware test: verify `WiFi.status()` returns `WL_DISCONNECTED` after an AUTH_EXPIRE event