### PR TITLE
fix: always symlink workspace for PlatformIO CI builds

### DIFF
--- a/.github/scripts/install-platformio-esp32.sh
+++ b/.github/scripts/install-platformio-esp32.sh
@@ -40,13 +40,8 @@ replace_script+="data['packages']['tool-esptoolpy']['version']='$ESPTOOLPY_VERSI
 replace_script+="fp.seek(0);fp.truncate();json.dump(data, fp, indent=2);fp.close()"
 python -c "$replace_script"
 
-if [ "$GITHUB_REPOSITORY" == "espressif/arduino-esp32" ];  then
-    echo "Linking Core..."
-    ln -s $GITHUB_WORKSPACE "$PLATFORMIO_ESP32_PATH"
-else
-    echo "Cloning Core Repository ..."
-    git clone --recursive https://github.com/espressif/arduino-esp32.git "$PLATFORMIO_ESP32_PATH" > /dev/null 2>&1
-fi
+echo "Linking Core..."
+ln -s $GITHUB_WORKSPACE "$PLATFORMIO_ESP32_PATH"
 
 echo "PlatformIO for ESP32 has been installed"
 echo ""


### PR DESCRIPTION
## Summary
- PlatformIO CI jobs have been failing on this fork since at least September 2025
- The `install-platformio-esp32.sh` script checked if `GITHUB_REPOSITORY == "espressif/arduino-esp32"` — since we're `bantamtools/arduino-esp32`, it took the `else` branch and cloned upstream master instead of using the checked-out workspace
- The cloned upstream code is incompatible with the PlatformIO platform version, causing a missing `platformio-build.py` error
- Fix: always symlink `$GITHUB_WORKSPACE`, which `actions/checkout` has already populated with our code

## Test plan
- [ ] Verify PlatformIO CI jobs pass on this PR