### PR TITLE
ci: fix PlatformIO builds and update deprecated runners

### DIFF
--- a/.github/scripts/install-platformio-esp32.sh
+++ b/.github/scripts/install-platformio-esp32.sh
@@ -40,13 +40,8 @@ replace_script+="data['packages']['tool-esptoolpy']['version']='$ESPTOOLPY_VERSI
 replace_script+="fp.seek(0);fp.truncate();json.dump(data, fp, indent=2);fp.close()"
 python -c "$replace_script"
 
-if [ "$GITHUB_REPOSITORY" == "espressif/arduino-esp32" ];  then
-    echo "Linking Core..."
-    ln -s $GITHUB_WORKSPACE "$PLATFORMIO_ESP32_PATH"
-else
-    echo "Cloning Core Repository ..."
-    git clone --recursive https://github.com/espressif/arduino-esp32.git "$PLATFORMIO_ESP32_PATH" > /dev/null 2>&1
-fi
+echo "Linking Core..."
+ln -s $GITHUB_WORKSPACE "$PLATFORMIO_ESP32_PATH"
 
 echo "PlatformIO for ESP32 has been installed"
 echo ""

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -81,7 +81,7 @@ jobs:
 
   build-esp-idf-component:
     name: Build with ESP-IDF ${{ matrix.idf_ver }} for ${{ matrix.idf_target }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # The version names here correspond to the versions of espressif/idf Docker image.


### PR DESCRIPTION
## Summary
Supersedes #4.

- **PlatformIO fix:** `install-platformio-esp32.sh` checked `GITHUB_REPOSITORY == "espressif/arduino-esp32"` — since we're `bantamtools/arduino-esp32`, it cloned upstream master instead of symlinking the workspace, causing a missing `platformio-build.py` error. Fix: always symlink `$GITHUB_WORKSPACE`.
- **Runner update:** ESP-IDF component build jobs used deprecated `ubuntu-20.04` runners and were stuck in queue indefinitely. Updated to `ubuntu-latest`.

## Test plan
- [ ] Verify PlatformIO CI jobs pass
- [ ] Verify ESP-IDF component build jobs start and complete