### PR TITLE
Backport PR #9991: setTimeout before _parseRequest

### DIFF
--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -310,10 +310,15 @@ void WebServer::handleClient() {
     case HC_WAIT_READ:
       // Wait for data from client to become available
       if (_currentClient.available()) {
+        // [PR #9991 backport] Set the socket timeout BEFORE _parseRequest so that
+        // large multipart body ingest (_parseForm / _uploadReadByte) inherits
+        // HTTP_MAX_SEND_WAIT rather than the WiFiClient default. Previously the
+        // timeout was only applied after parsing completed, which meant slow-drain
+        // body reads would time out via the much shorter default and abort the
+        // connection. HTTP_MAX_SEND_WAIT is in milliseconds; our WiFiClient API
+        // takes seconds, so /1000 remains correct for this fork.
+        _currentClient.setTimeout(HTTP_MAX_SEND_WAIT / 1000);
         if (_parseRequest(_currentClient)) {
-          // because HTTP_MAX_SEND_WAIT is expressed in milliseconds,
-          // it must be divided by 1000
-          _currentClient.setTimeout(HTTP_MAX_SEND_WAIT / 1000);
           _contentLength = CONTENT_LENGTH_NOT_SET;
           _handleRequest();
 


### PR DESCRIPTION
Clean single-commit backport of upstream espressif/arduino-esp32#9991 to this fork's `master` (the branch FluidNC's production build actually pulls from via tag `v2.0.14-20260412`).

## What it changes

Three lines in `libraries/WebServer/src/WebServer.cpp` — moves `_currentClient.setTimeout(HTTP_MAX_SEND_WAIT / 1000)` from after `_parseRequest()` to before it in `handleClient()`:

```diff
   if (_currentClient.available()) {
+    _currentClient.setTimeout(HTTP_MAX_SEND_WAIT / 1000);
     if (_parseRequest(_currentClient)) {
-      // HTTP_MAX_SEND_WAIT is expressed in milliseconds, divide by 1000
-      _currentClient.setTimeout(HTTP_MAX_SEND_WAIT / 1000);
       _contentLength = CONTENT_LENGTH_NOT_SET;
       _handleRequest();
```

The `/1000` divisor is retained because this branch's `WiFiClient::setTimeout` takes seconds (matches the 2.0.14 API shape).

## Why

`_parseRequest()` invokes `_parseForm()` which calls `_uploadReadByte()` per body byte. `_uploadReadByte()` uses `client.getTimeout()` as its per-byte read timeout. Before this change, the timeout was only set AFTER `_parseRequest()` returned, so during actual body ingest the WiFiClient default timeout was in effect, which is much shorter than `HTTP_MAX_SEND_WAIT` (30 s).

Under TCP backpressure from a slow drain pipeline on the receiving device, the default timeout fires, `_uploadReadByte` returns -1, `_parseFormUploadAborted` runs, and the multipart upload terminates at an unpredictable byte offset. With the timeout applied earlier, brief flow-control pauses during body ingest inherit the full `HTTP_MAX_SEND_WAIT` budget and large uploads complete reliably.

Full diagnosis in bantamtools/FluidNC-Private#475.

## Provenance and testing

  - Upstream commit: [espressif/arduino-esp32#9991](https://github.com/espressif/arduino-esp32/pull/9991) (merged to upstream master), which closes upstream issue #9990
  - Fork commit: `558028c2e` authored 2026-04-18 by @devin-cooper-bt, originally on `fix/upload-backpressure`
  - Cherry-picked here onto a clean branch from `master` to produce a minimal review surface (no other `fix/upload-backpressure` experimental commits included)

Tested on ESP32-S3 / FluidNC on `diag/475-three-timer` builds (which pin to a fork commit with this change in its ancestry): multi-MB SD uploads that previously aborted intermittently at ~30 s of cumulative backpressure now complete to end-of-file. Paired diagnostic measurements summarized in bantamtools/FluidNC-Private#475.

## Follow-up

After this PR merges, FluidNC-Private needs a corresponding submodule update via the standard `/submodule-pr` workflow: tag the new `master` commit (or have FluidNC pin to commit SHA directly), bump `platform_packages` in FluidNC's `platformio.ini`, bump the submodule pointer. A companion FluidNC-side change removing a per-chunk `vTaskDelay(1)` in `uploadWrite` is also being tracked separately.